### PR TITLE
Stackoverflow -> Stack Overflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "cSpell.words": [
         "Callstack",
-        "Stackoverflow",
         "initialise"
     ]
 }

--- a/docs/guides/useful-links.md
+++ b/docs/guides/useful-links.md
@@ -58,7 +58,7 @@ and improving your skills.
 
 ## Surveys
 
-- [StackOverFlow Developer Survey Results 2019](https://insights.stackoverflow.com/survey/2019)
+- [Stack Overflow Developer Survey Results 2019](https://insights.stackoverflow.com/survey/2019)
 - [State of JS 2019](https://2019.stateofjs.com/)
 - [State of CSS 2019](https://2019.stateofcss.com/)
 - [Screen Reader User Survey #7 Results](https://webaim.org/projects/screenreadersurvey7/)

--- a/docs/js-core-3/week-1/lesson.md
+++ b/docs/js-core-3/week-1/lesson.md
@@ -177,9 +177,9 @@ When debugging, it can often be useful to write down what values variables have,
 
 It is important when working on your code to test each part of your code separately and carefully. Make sure everything is working before you move on to the next part otherwise problems become harder to debug.
 
-##### Stackoverflow.com
+##### Stack Overflow
 
-[Stackoverflow](https://stackoverflow.com/) is a crucial tool for lots of new developers in finding answers to their programming problems. While a lot of the information is very good there are several points to keep in mind.
+[Stack Overflow](https://stackoverflow.com/) is a crucial tool for lots of new developers in finding answers to their programming problems. While a lot of the information is very good there are several points to keep in mind.
 
 - Information goes out of date very quickly
   - You have to make sure that what your looking at it new

--- a/docs/workshops/js-testing-workshop.md
+++ b/docs/workshops/js-testing-workshop.md
@@ -44,7 +44,7 @@ There are typically several levels of testing when working on a project:
 - Integration testing
 - Functional, End to End testing and User Acceptance Testing (UAT)
 
-[This answer from Stack OverFlow](https://stackoverflow.com/a/4904533) has a good explanation of types of testing. The defintions for Functional, e2e and UAT are often mean different things in different teams, the responisibility for them also falls on different individuals depending on the team.
+[This answer from Stack Overflow](https://stackoverflow.com/a/4904533) has a good explanation of types of testing. The defintions for Functional, e2e and UAT are often mean different things in different teams, the responisibility for them also falls on different individuals depending on the team.
 
 _Unit testing_ though is always the responsibility of the Developer, and it is a very important skill for any professional developer to be able to write tests, and also write code that is testable.
 

--- a/docs/workshops/welcome-to-cyf.md
+++ b/docs/workshops/welcome-to-cyf.md
@@ -21,7 +21,7 @@ sidebar_label: Welcome to CYF
 - Who we are?
 - What will we learn?
   - Read this Technology Survey from
-    [StackOverflow](https://insights.stackoverflow.com/survey/2019).
+    [Stack Overflow](https://insights.stackoverflow.com/survey/2019).
     Pay particular attention to the technologies we'll be teaching you
     (JavaScript, React, NodeJS)
 - [House Rules](https://docs.codeyourfuture.io/students/house-rules)
@@ -160,7 +160,7 @@ It's like Dropbox for developers. But much better!
 > Extract from
 > [Git Pro book](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
 
-This [answer](https://stackoverflow.com/a/1408464) on StackOverflow by
+This [answer](https://stackoverflow.com/a/1408464) on Stack Overflow by
 si618 explains very well why we use Version Control.
 
 So what is **Git**? Git is one of many Version Control Systems available to use,


### PR DESCRIPTION
Per https://stackoverflow.com/legal/trademark-guidance:

> As a name, Stack Overflow, is always written "Stack Overflow" (two words, capital letters).