### PR TITLE
Fix broken link to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In this Syllabus you'll find the content that we teach at CodeYourFuture. For ot
 
 ## Contributing
 
-Please read our [Contributing guide](./contributing.md) to get started with how you can contribute to the CodeYourFuture Syllabus.
+Please read our [Contributing guide](./docs/fundamentals/contributing.md) to get started with how you can contribute to the CodeYourFuture Syllabus.
 
 ## Contributors ✨
 


### PR DESCRIPTION
## What does this change?

Fix broken link to contributing guide

Module: n/a
Week(s): n/a

## Description

The path to the contributing guide doesn't exist in the project.

This change references the correct path to contributing guide.

<!--
  For ease of review, consider adding a "rendered" version (using GitHub's
  markdown renderer) of the file(s) that you changed by adding a link in this
  format:

  [Rendered version](https://github.com/CodeYourFuture/syllabus/blob/YOUR_BRANCH_NAME/PATH/TO/THE/CHANGED/FILE.md)
-->

## Who needs to know about this?

<!---
Tag anyone who might want to be notified about this PR
-->
