### PR TITLE
Strip out conditional installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,7 @@ jobs:
           node-version: "12.x"
       - name: Test Build
         run: |
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
           npm ci
-          else
-          npm i
-          fi
           npm run build
   gh-release:
     if: github.event_name != 'pull_request'
@@ -51,13 +45,7 @@ jobs:
           USE_SSH: true
           GIT_USER: git
         run: |
-          git config --global user.email "actions@gihub.com"
+          git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
-          if [ -e yarn.lock ]; then
-          yarn install --frozen-lockfile
-          elif [ -e package-lock.json ]; then
           npm ci
-          else
-          npm i
-          fi
           npx docusaurus deploy


### PR DESCRIPTION
## What does this change?

Module: N/A
Week(s): N/A

## Description

There should no longer be a `yarn.lock`, and the build should fail if the NPM lockfile is out-of-sync. Therefore to simplify the build process, we can strip out the conditional installation.

## Who needs to know about this?

@ChrisOwen101 - I think this is the only part of #59 that hasn't already made it into `master`!