### PR TITLE
Add Demo component to render components within the syllabus itself

### DIFF
--- a/docs/react/week-2/demos/ExerciseA.js
+++ b/docs/react/week-2/demos/ExerciseA.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseADemo() {
+  function logWhenClicked() {
+    console.log("Clicked!");
+  }
+  return (
+    <Demo>
+      <header>
+        <h1>Welcome to the Pokedex</h1>
+        <img
+          onClick={logWhenClicked}
+          src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/016.png"
+          alt="Pokedex"
+          style={{ maxWidth: "200px" }}
+        />
+      </header>
+    </Demo>
+  );
+}

--- a/docs/react/week-2/demos/ExerciseA.js
+++ b/docs/react/week-2/demos/ExerciseA.js
@@ -14,6 +14,7 @@ export function ExerciseADemo() {
           onClick={logWhenClicked}
           src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/016.png"
           alt="Pokedex"
+          // Restrict the image size to fit better
           style={{ maxWidth: "200px" }}
         />
       </header>

--- a/docs/react/week-2/lesson.md
+++ b/docs/react/week-2/lesson.md
@@ -4,6 +4,8 @@ title: React - Week 2
 sidebar_label: Lesson
 ---
 
+import { ExerciseADemo } from './demos/ExerciseA.js'
+
 ---
 
 Click [here](./learning-objectives) to see the Learning Objectives for this lesson.
@@ -108,6 +110,7 @@ Think of it like this: we give the event handler to React, so that React can cal
 
 | Exercise A (estimate: 10 min)                                                                                                             |
 | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise we will extend our `Logo` component to log to the console when clicking on the image. <ExerciseADemo />                  |
 | 1. Open the `pokedex` React application from last week and open the `Logo.js` file.                                                       |
 | 2. Add a function named `logWhenClicked` within the `Logo` component. (Hint: look at the example above).                                  |
 | 3. In the `logWhenClicked` function, `console.log` a message (it doesn't matter what the message is).                                     |
@@ -331,7 +334,7 @@ On the second render, `count` is now set to 1. Every time we click the button, t
 | 2. Create a new state variable with `useState`. It should be named `caught` and be initialised to `0`                                                                                                                                                                                                                                                                                         |
 | 3. Within the JSX, there should be a "hard-coded" number 0. Replace it with your new `caught` state.                                                                                                                                                                                                                                                                                          |
 | 4. Add a button to the component with an `onClick` handler that calls a function called `catchPokemon`.                                                                                                                                                                                                                                                                                       |
-| 5. Create the `catchPokemon` function and have it update the `caught` state so that it is increased by 1 on each click. <details><summary>Click here if you are stuck.</summary>You will need to call the set state function (the 2nd item in the `useState` array) with `caught + 1`.</details>                                                                                                      |
+| 5. Create the `catchPokemon` function and have it update the `caught` state so that it is increased by 1 on each click. <details><summary>Click here if you are stuck.</summary>You will need to call the set state function (the 2nd item in the `useState` array) with `caught + 1`.</details>                                                                                              |
 | 6. Write down the things that will happen when you click the button. Compare your list with another student and discuss. <details><summary>Click here for a hint.</summary>The state will be updated to be the current state + 1. React is notified that our state has changed, so it re-renders. When rendering, the current state will be different and so React updates the DOM.</details> |
 
 #### Don't mutate State

--- a/src/theme/Demo.css
+++ b/src/theme/Demo.css
@@ -1,0 +1,22 @@
+.demo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid var(--ifm-color-info);
+  border-radius: 8px;
+  position: relative;
+}
+
+.demo:before {
+  content: "demo";
+  position: absolute;
+  top: 0.5em;
+  left: 0.5em;
+  font-size: calc(var(--ifm-font-size-base) * 0.65);
+  text-transform: uppercase;
+}
+
+.demo__wrapper {
+  width: 80%;
+  margin-top: 1rem;
+}

--- a/src/theme/Demo.js
+++ b/src/theme/Demo.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+import "./Demo.css";
+
+export default function Demo(props) {
+  return (
+    <div className="demo">
+      <div className="demo__wrapper">{props.children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this change?

Adds infrastructural `Demo` "theme" component, available to all modules.

Module: N/A
Week(s): N/A

## Description

Adds a `Demo` ["theme" component](https://v2.docusaurus.io/docs/using-themes/), which allows the injection of a React component into the syllabus.

This allows for demos to be shown for examples/exercises directly inline. I've included a demo for the React module, but it would be possible to add demos for other modules (e.g. HTML/CSS) via this mechanism.

My intention is to follow this PR up with another that adds demos for all of the React module in-class exercises. This addresses a common bit of feedback that students don't know what the end goal of the exercise is. cc @nbogie 

## Who needs to know about this?

@ChrisOwen101 