### PR TITLE
Add demos for in-class React exercises

### DIFF
--- a/docs/react/week-1/demos/ExerciseD.js
+++ b/docs/react/week-1/demos/ExerciseD.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseDDemo() {
+  return (
+    <Demo>
+      <div>
+        <header>
+          <h1>Welcome to the Pokedex</h1>
+          <img
+            src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/016.png"
+            alt="Pokedex"
+            // Restrict the image size to fit better
+            style={{ maxWidth: "200px" }}
+          />
+        </header>
+      </div>
+    </Demo>
+  );
+}

--- a/docs/react/week-1/demos/ExerciseE.js
+++ b/docs/react/week-1/demos/ExerciseE.js
@@ -1,0 +1,32 @@
+import React from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseEDemo() {
+  return (
+    <Demo>
+      <div>
+        <Logo />
+        <BestPokemon />
+      </div>
+    </Demo>
+  );
+}
+
+function Logo() {
+  return (
+    <header>
+      <h1>Welcome to the Pokedex</h1>
+      <img
+        src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/016.png"
+        alt="Pokedex"
+        // Restrict the image size to fit better
+        style={{ maxWidth: "200px" }}
+      />
+    </header>
+  );
+}
+
+function BestPokemon() {
+  return <p>My favourite Pokemon is Squirtle</p>;
+}

--- a/docs/react/week-1/demos/ExerciseG.js
+++ b/docs/react/week-1/demos/ExerciseG.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseGDemo() {
+  return (
+    <Demo>
+      <div>
+        <Logo />
+        <BestPokemon />
+        <CaughtPokemon />
+      </div>
+    </Demo>
+  );
+}
+
+function Logo() {
+  const appName = "CYF's Pokedex";
+
+  return (
+    <header>
+      <h1>Welcome to {appName}</h1>
+      <img
+        src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/016.png"
+        alt="Pokedex"
+        // Restrict the image size to fit better
+        style={{ maxWidth: "200px" }}
+      />
+    </header>
+  );
+}
+
+function BestPokemon() {
+  const abilities = ["Anticipation", "Adaptability", "Run-Away"];
+
+  return (
+    <div>
+      <p>My favourite Pokemon is Squirtle</p>
+      <ul>
+        {abilities.map((ability, index) => {
+          return <li key={index}>{ability}</li>;
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function CaughtPokemon() {
+  const date = new Date().toLocaleDateString();
+
+  return <p>Caught 0 Pokemon on {date}</p>;
+}

--- a/docs/react/week-1/lesson.md
+++ b/docs/react/week-1/lesson.md
@@ -5,6 +5,9 @@ sidebar_label: Lesson
 ---
 
 import Feedback from "@theme/Feedback";
+import { ExerciseDDemo } from './demos/ExerciseD.js'
+import { ExerciseEDemo } from './demos/ExerciseE.js'
+import { ExerciseGDemo } from './demos/ExerciseG.js'
 
 ---
 
@@ -144,6 +147,7 @@ The process of _rendering_ is turning the JSX elements returned by the component
 
 | Exercise D (estimate: 10 min)                                                                                                                                                                                                             |
 | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise we replace the placeholder React app with our own. It should look like this: <ExerciseDDemo />                                                                                                                           |
 | 1. In the `pokedex` React app that you just created, open the `src/App.js` file.                                                                                                                                                          |
 | 2. Delete everything in the file except the line containing `export default App`. You should see an error in your terminal and in your web browser - don't panic! We're going to remake the `App` component ourselves.                    |
 | 3. Import the React variable from the React package.                                                                                                                                                                                      |
@@ -184,6 +188,7 @@ Notice how the components that we write (`HelloWorld`, `Greeting`, `Mentor`) are
 
 | Exercise E (estimate: 5 min)                                                                                                                                                       |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we will split out a new `Logo` component from the `App` component. And then we'll add a new `BestPokemon` component: <ExerciseEDemo />                           |
 | 1. In your `pokedex` React app, open the `src/App.js` file.                                                                                                                        |
 | 2. Create a new function named `Logo`.                                                                                                                                             |
 | 3. Copy the `<header>` element and its contents and paste it into the `Logo` component.                                                                                            |
@@ -230,10 +235,11 @@ const HelloWorld = () => (
 
 If we want to do this, we can still use arrow functions but we can't use the implicit return.
 
-| Exercise F (estimate: 5 min)                                                           |
-| :------------------------------------------------------------------------------------- |
-| 1. Using the `pokedex` React app that you created earlier, open the `src/App.js` file. |
-| 2. Convert the `Logo` and `BestPokemon` functions into arrow functions.                |
+| Exercise F (estimate: 5 min)                                                                                                         |
+| :----------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll convert the Pokedex app to use arrow functions. It should still look the same in your browser as Exercise E. |
+| 1. Using the `pokedex` React app that you created earlier, open the `src/App.js` file.                                               |
+| 2. Convert the `Logo` and `BestPokemon` functions into arrow functions.                                                              |
 
 ## Embedding JavaScript into JSX
 
@@ -313,17 +319,18 @@ function MentorsList() {
 
 Here we are using `Array.map` to turn an array of strings into an array of components.
 
-| Exercise G (estimate: 10 min)                                                                                                                                                                                           |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1. Using the `pokedex` React app that you created earlier, open the `src/App.js` file.                                                                                                                                  |
-| 2. Inside the `Logo` component create a new variable called `appName` and assign it to `"Pokedex"`.                                                                                                                     |
-| 3. Now replace the hard-coded app name with `{appName}`. What do you see in your web browser? What would you do if you wanted to change the app name?                                                                   |
-| 4. Create a new component named `CaughtPokemon`. Within this component return a `<p>` tag with the text "Caught 0 Pokemon on" (we're going to fill in today's date in the next step).                                   |
-| 5. Create a variable named `date` within the `CaughtPokemon` component, and assign it today's date (hint: `new Date().toLocaleDateString()`). Finally, render the `date` variable after the text "Caught 0 Pokemon on". |
-| 6. Render the `CaughtPokemon` component within the `App` component (below `BestPokemon`).                                                                                                                               |
-| 7. Within the `BestPokemon` component, create a variable named `abilities` and assign it to an array with some Pokemon abilities (e.g. `['Anticipation', 'Adaptability', 'Run-Away']`).                                 |
-| 8. Change the `BestPokemon` component to return a `<div>` element with the existing `<p>` element inside it. Then add a `<ul>` element underneath the `<p>` element.                                                    |
-| 9. Now use the `.map()` method on the `abilities` variable to loop over each name and return a `<li>` element for each (hint: look at the mentors list example above) within the `<ul>` element.                        |
+| Exercise G (estimate: 10 min)                                                                                                                                                                                                                        |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll change the `Logo` component to use a variable for the app name. Then we'll add a new component `CaughtPokemon` which displays today's date. And finally we'll make `BestPokemon` show a list of abilities: <ExerciseGDemo /> |
+| 1. Using the `pokedex` React app that you created earlier, open the `src/App.js` file.                                                                                                                                                               |
+| 2. Inside the `Logo` component create a new variable called `appName` and assign it to `"[YOUR_NAME]'s Pokedex"`.                                                                                                                                    |
+| 3. Now replace the hard-coded app name with `{appName}`. What do you see in your web browser? What would you do if you wanted to change the app name?                                                                                                |
+| 4. Create a new component named `CaughtPokemon`. Within this component return a `<p>` tag with the text "Caught 0 Pokemon on" (we're going to fill in today's date in the next step).                                                                |
+| 5. Create a variable named `date` within the `CaughtPokemon` component, and assign it today's date (hint: `new Date().toLocaleDateString()`). Finally, render the `date` variable after the text "Caught 0 Pokemon on".                              |
+| 6. Render the `CaughtPokemon` component within the `App` component (below `BestPokemon`).                                                                                                                                                            |
+| 7. Within the `BestPokemon` component, create a variable named `abilities` and assign it to an array with some Pokemon abilities (e.g. `['Anticipation', 'Adaptability', 'Run-Away']`).                                                              |
+| 8. Change the `BestPokemon` component to return a `<div>` element with the existing `<p>` element inside it. Then add a `<ul>` element underneath the `<p>` element.                                                                                 |
+| 9. Now use the `.map()` method on the `abilities` variable to loop over each name and return a `<li>` element for each (hint: look at the mentors list example above) within the `<ul>` element.                                                     |
 
 ## Keys
 
@@ -375,16 +382,17 @@ export default Greeting;
 
 The convention is to name component files exactly the same as the component (including the capital letter).
 
-| Exercise H (estimate: 5 min)                                                                                                |
-| :-------------------------------------------------------------------------------------------------------------------------- |
-| 1. Open the `pokedex` React app that you created earlier.                                                                   |
-| 2. Create a new file within the `src` directory named `Logo.js`.                                                            |
-| 3. Copy and paste the `Logo` component from `App.js` into `Logo.js`.                                                        |
-| 4. Remember to add `import React from 'react'` at the top of `Logo.js`.                                                     |
-| 5. Export the `Logo` component from `Logo.js` (hint: look at the `Greeting` example above).                                 |
-| 6. Delete the old `Logo` component from `App.js`.                                                                           |
-| 7. Import the `Logo` component into `App.js` (hint: look at the `HelloMentor` example above).                               |
-| 8. Repeat this process with the `BestPokemon` and `CaughtPokemon` components. What do you think the files should be called? |
+| Exercise H (estimate: 5 min)                                                                                                    |
+| :------------------------------------------------------------------------------------------------------------------------------ |
+| In this exercise, we'll split the Pokedex app into separate files. It should still look the same in your browser as Exercise G. |
+| 1. Open the `pokedex` React app that you created earlier.                                                                       |
+| 2. Create a new file within the `src` directory named `Logo.js`.                                                                |
+| 3. Copy and paste the `Logo` component from `App.js` into `Logo.js`.                                                            |
+| 4. Remember to add `import React from 'react'` at the top of `Logo.js`.                                                         |
+| 5. Export the `Logo` component from `Logo.js` (hint: look at the `Greeting` example above).                                     |
+| 6. Delete the old `Logo` component from `App.js`.                                                                               |
+| 7. Import the `Logo` component into `App.js` (hint: look at the `HelloMentor` example above).                                   |
+| 8. Repeat this process with the `BestPokemon` and `CaughtPokemon` components. What do you think the files should be called?     |
 
 ## Making an argument for Props
 
@@ -435,20 +443,21 @@ Or calculating new values:
 <div>{props.age + 1}</div>
 ```
 
-| Exercise I (estimate: 10 min)                                                                                                                                                 |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1. Using the `pokedex` React app that you created earlier, open the `App.js` file.                                                                                            |
-| 2. Pass a prop `appName="Pokedex"` to the `Logo` component.                                                                                                                   |
-| 3. Now open the `Logo.js` file.                                                                                                                                               |
-| 4. Delete the `appName` variable. What do you see in your web browser? Why?                                                                                                   |
-| 5. Change the `Logo` function to access the first argument and call it `props`. Use `console.log` to inspect the `props` variable.                                            |
-| 6. Change the usage of `appName` in the `<h1>` to be `props.appName` instead. Does this fix the problem? Why?                                                                 |
-| 7. Now open the `BestPokemon.js` file.                                                                                                                                        |
-| 8. Copy the `abilities` variable and then delete it from `BestPokemon.js`.                                                                                                    |
-| 9. Paste the `abilities` variable into `App.js`.                                                                                                                              |
-| 10. Pass the `abilities` variable as a prop to `BestPokemon` from `App.js`.                                                                                                   |
-| 11. In the `BestPokemon.js` file replace the existing usage of `abilities` with the `abilities` **prop**. You should still see the Pokemon ability names in your web browser. |
-| 12. **(STRETCH GOAL)** Repeat the process with the `date` variable in the `CaughtPokemon.js` file.                                                                            |
+| Exercise I (estimate: 10 min)                                                                                                                                                                                                                                 |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| In this exercise, we'll move the variables in `Logo`, `BestPokemon` and `CaughtPokemon` to the `App` component. Then we'll make `App` pass those variables as props to the sub-components. Your app should still look the same in your browser as Exercise H. |
+| 1. Using the `pokedex` React app that you created earlier, open the `App.js` file.                                                                                                                                                                            |
+| 2. Pass a prop `appName="Pokedex"` to the `Logo` component.                                                                                                                                                                                                   |
+| 3. Now open the `Logo.js` file.                                                                                                                                                                                                                               |
+| 4. Delete the `appName` variable. What do you see in your web browser? Why?                                                                                                                                                                                   |
+| 5. Change the `Logo` function to access the first argument and call it `props`. Use `console.log` to inspect the `props` variable.                                                                                                                            |
+| 6. Change the usage of `appName` in the `<h1>` to be `props.appName` instead. Does this fix the problem? Why?                                                                                                                                                 |
+| 7. Now open the `BestPokemon.js` file.                                                                                                                                                                                                                        |
+| 8. Copy the `abilities` variable and then delete it from `BestPokemon.js`.                                                                                                                                                                                    |
+| 9. Paste the `abilities` variable into `App.js`.                                                                                                                                                                                                              |
+| 10. Pass the `abilities` variable as a prop to `BestPokemon` from `App.js`.                                                                                                                                                                                   |
+| 11. In the `BestPokemon.js` file replace the existing usage of `abilities` with the `abilities` **prop**. You should still see the Pokemon ability names in your web browser.                                                                                 |
+| 12. **(STRETCH GOAL)** Repeat the process with the `date` variable in the `CaughtPokemon.js` file.                                                                                                                                                            |
 
 ### Credits
 

--- a/docs/react/week-1/lesson.md
+++ b/docs/react/week-1/lesson.md
@@ -4,6 +4,9 @@ title: React - Week 1
 sidebar_label: Lesson
 ---
 
+<!-- Docusaurus allows embedding React components via MDX -->
+<!-- https://v2.docusaurus.io/docs/markdown-features#embedding-react-components-with-mdx -->
+
 import Feedback from "@theme/Feedback";
 import { ExerciseDDemo } from './demos/ExerciseD.js'
 import { ExerciseEDemo } from './demos/ExerciseE.js'

--- a/docs/react/week-1/mentors.md
+++ b/docs/react/week-1/mentors.md
@@ -23,6 +23,7 @@ If you students do not arrive with these steps completed then you will lose a lo
 
 - [PokeDex In-Class - Exercise Solution - 05/06/2020](https://github.com/CodeYourFuture/pokedex-solution)
   - Created by London and Ali Smith
+  - These are now embedded into the syllabus itself, see [`demos` folder](https://github.com/CodeYourFuture/syllabus/tree/master/docs/react/week-1/demos) for source
 - [Hotel Homework - Solution - 24/07/2020](https://github.com/CodeYourFuture/Hotel-React-solution)
   - Created by Manchester and Dorota Sobkow
 

--- a/docs/react/week-2/demos/ExerciseD.js
+++ b/docs/react/week-2/demos/ExerciseD.js
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseDDemo() {
+  return (
+    <Demo>
+      <CaughtPokemon date={new Date().toLocaleDateString()} />
+    </Demo>
+  );
+}
+
+function CaughtPokemon(props) {
+  const [caught, setCaught] = useState(0);
+
+  function catchPokemon() {
+    setCaught(caught + 1);
+  }
+
+  return (
+    <p>
+      Caught {caught} Pokemon on {props.date}
+      <button onClick={catchPokemon}>Catch Pokemon</button>
+    </p>
+  );
+}

--- a/docs/react/week-2/demos/ExerciseE.js
+++ b/docs/react/week-2/demos/ExerciseE.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseEDemo() {
+  return (
+    <Demo>
+      <CaughtPokemon date={new Date().toLocaleDateString()} />
+    </Demo>
+  );
+}
+
+function CaughtPokemon(props) {
+  const [caught, setCaught] = useState([]);
+
+  function catchPokemon() {
+    setCaught(caught.concat(getRandomPokemon()));
+  }
+
+  return (
+    <p>
+      Caught {caught.length} Pokemon on {props.date}
+      <ul>
+        {caught.map((name, index) => {
+          return <li key={index}>{name}</li>;
+        })}
+      </ul>
+      <button onClick={catchPokemon}>Catch Pokemon</button>
+    </p>
+  );
+}
+
+function getRandomPokemon() {
+  const pokemon = ["Ditto", "Eevee", "Pikachu", "Butterfree", "Spearow"];
+  return pokemon[Math.floor(Math.random() * pokemon.length)];
+}

--- a/docs/react/week-2/lesson.md
+++ b/docs/react/week-2/lesson.md
@@ -6,6 +6,8 @@ sidebar_label: Lesson
 
 import Feedback from "@theme/Feedback";
 import { ExerciseADemo } from './demos/ExerciseA.js'
+import { ExerciseDDemo } from './demos/ExerciseD.js'
+import { ExerciseEDemo } from './demos/ExerciseE.js'
 
 ---
 
@@ -151,14 +153,15 @@ function FancyButton(props) {
 
 Notice how this is very similar to the example above where we created the handler and used it in the same component? The only difference here is that we are passing the function reference through a prop. We could even pass it through multiple components as props.
 
-| Exercise B (estimate: 10 min)                                                                                                                                 |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1. Open the `pokedex` React application and open the `Logo.js` file.                                                                                          |
-| 2. Copy and paste the `logWhenClicked` function from the `Logo` component to the `App` component.                                                             |
-| 3. Pass the `logWhenClicked` function **reference** as a prop to the `Logo` component. (Hint: look at the `ClickLoggerApp` component above for an example).   |
-| 4. In the `Logo` component change the `onClick` prop so that it passes `props.handleClick`. (Hint: look at the `FancyButton` component above for an example). |
-| 5. In a group of 2 - 3 students, discuss what you think will happen when you click the logo image now. Can you explain why?                                   |
-| 6. Report back to the rest of the class what you thought was going to happen and why.                                                                         |
+| Exercise B (estimate: 10 min)                                                                                                                                                                                                                            |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll move the `logWhenClicked` function in the `Logo` component to the `App` component. Then we'll make `App` pass those variables as props to the sub-components. Your app should still look the same in your browser as Exercise A. |
+| 1. Open the `pokedex` React application and open the `Logo.js` file.                                                                                                                                                                                     |
+| 2. Copy and paste the `logWhenClicked` function from the `Logo` component to the `App` component.                                                                                                                                                        |
+| 3. Pass the `logWhenClicked` function **reference** as a prop to the `Logo` component. (Hint: look at the `ClickLoggerApp` component above for an example).                                                                                              |
+| 4. In the `Logo` component change the `onClick` prop so that it passes `props.handleClick`. (Hint: look at the `FancyButton` component above for an example).                                                                                            |
+| 5. In a group of 2 - 3 students, discuss what you think will happen when you click the logo image now. Can you explain why?                                                                                                                              |
+| 6. Report back to the rest of the class what you thought was going to happen and why.                                                                                                                                                                    |
 
 ## Re-rendering components
 
@@ -331,6 +334,7 @@ On the second render, `count` is now set to 1. Every time we click the button, t
 
 | Exercise D (estimate: 15 min)                                                                                                                                                                                                                                                                                                                                                                 |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll add a button to the `CaughtPokemon` component which adds one to the number of Pokemon you have caught: <ExerciseDDemo />                                                                                                                                                                                                                                              |
 | 1. Open the `pokedex` React application and open the `CaughtPokemon.js` file.                                                                                                                                                                                                                                                                                                                 |
 | 2. Create a new state variable with `useState`. It should be named `caught` and be initialised to `0`                                                                                                                                                                                                                                                                                         |
 | 3. Within the JSX, there should be a "hard-coded" number 0. Replace it with your new `caught` state.                                                                                                                                                                                                                                                                                          |
@@ -410,6 +414,7 @@ The `list.push` method won't work here, as this method _mutates_ the existing ar
 
 | Exercise E (estimate: 10 min)                                                                                                                                                                                                                                                         |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| In this exercise, we'll change the `CaughtPokemon` component to show a list of Pokemon that we have caught instead of a number: <ExerciseEDemo />                                                                                                                                     |
 | 1. Open the `pokedex` React application and open the `CaughtPokemon.js` file.                                                                                                                                                                                                         |
 | 2. Change the `useState` to be initialised to an empty array (`[]`)                                                                                                                                                                                                                   |
 | 3. There will now be a bug in your app! We don't see how many Pokemon we have caught. Discuss with another student what you think the problem is.                                                                                                                                     |

--- a/docs/react/week-2/lesson.md
+++ b/docs/react/week-2/lesson.md
@@ -4,6 +4,9 @@ title: React - Week 2
 sidebar_label: Lesson
 ---
 
+<!-- Docusaurus allows embedding React components via MDX -->
+<!-- https://v2.docusaurus.io/docs/markdown-features#embedding-react-components-with-mdx -->
+
 import Feedback from "@theme/Feedback";
 import { ExerciseADemo } from './demos/ExerciseA.js'
 import { ExerciseDDemo } from './demos/ExerciseD.js'

--- a/docs/react/week-2/mentors.md
+++ b/docs/react/week-2/mentors.md
@@ -13,6 +13,7 @@ sidebar_label: Instructor Notes
 
 - [PokeDex In-Class - Exercise Solution - 05/06/2020](https://github.com/CodeYourFuture/pokedex-solution)
   - Created by London and Ali Smith
+  - These are now embedded into the syllabus itself, see [`demos` folder](https://github.com/CodeYourFuture/syllabus/tree/master/docs/react/week-2/demos) for source
 - [Hotel Homework - Solution - 24/07/2020](https://github.com/CodeYourFuture/Hotel-React-solution)
   - Created by Manchester and Dorota Sobkow
 

--- a/docs/react/week-3/demos/ExerciseA.js
+++ b/docs/react/week-3/demos/ExerciseA.js
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseADemo() {
+  return (
+    <Demo>
+      <PokemonMoves />
+    </Demo>
+  );
+}
+
+function PokemonMoves() {
+  const [pokemonData, setPokemonData] = useState(null);
+
+  useEffect(() => {
+    fetch("https://pokeapi.co/api/v2/pokemon/1/")
+      .then((res) => res.json())
+      .then((data) => {
+        console.log(data);
+        setPokemonData(data);
+      });
+  }, []);
+
+  if (pokemonData) {
+    return (
+      <div>
+        <p>{pokemonData.name}'s moves:</p>
+        <ul>
+          {/* Restrict the data to only 5 items to make it fit better */}
+          {pokemonData.moves.slice(0, 5).map((move, index) => {
+            return <li key={index}>{move.move.name}</li>;
+          })}
+        </ul>
+      </div>
+    );
+  } else {
+    return null;
+  }
+}

--- a/docs/react/week-3/demos/ExerciseE.js
+++ b/docs/react/week-3/demos/ExerciseE.js
@@ -1,0 +1,55 @@
+import React, { useState, useEffect } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseEDemo() {
+  return (
+    <Demo>
+      <PokemonMovesSelector />
+    </Demo>
+  );
+}
+
+function PokemonMovesSelector() {
+  const [id, setId] = useState(null);
+
+  function handleBulbasaurClick() {
+    setId(1);
+  }
+  function handleCharmanderClick() {
+    setId(4);
+  }
+
+  return (
+    <div>
+      <button onClick={handleBulbasaurClick}>Fetch Bulbasaur</button>
+      <button onClick={handleCharmanderClick}>Fetch Charmander</button>
+      {id ? <PokemonMoves pokemonId={id} /> : null}
+    </div>
+  );
+}
+
+function PokemonMoves(props) {
+  const [pokemonData, setPokemonData] = useState(null);
+
+  useEffect(() => {
+    fetch(`https://pokeapi.co/api/v2/pokemon/${props.pokemonId}/`)
+      .then((res) => res.json())
+      .then((data) => {
+        console.log(data);
+        setPokemonData(data);
+      });
+  }, [props.pokemonId]);
+
+  return pokemonData ? (
+    <div>
+      <p>{pokemonData.name}'s moves:</p>
+      <ul>
+        {/* Restrict the data to only 5 items to make it fit better */}
+        {pokemonData.moves.slice(0, 5).map((move, index) => {
+          return <li key={index}>{move.move.name}</li>;
+        })}
+      </ul>
+    </div>
+  ) : null;
+}

--- a/docs/react/week-3/demos/ExerciseF.js
+++ b/docs/react/week-3/demos/ExerciseF.js
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseFDemo() {
+  return (
+    <Demo>
+      <PokemonCity />
+    </Demo>
+  );
+}
+
+function PokemonCity() {
+  const [city, setCity] = useState("");
+
+  function updateCity(event) {
+    console.log(event.target.value);
+    setCity(event.target.value);
+  }
+
+  return (
+    <div>
+      <input type="text" value={city} onChange={updateCity} />
+      <p>Welcome to the city of {city}</p>
+    </div>
+  );
+}

--- a/docs/react/week-3/demos/ExerciseG.js
+++ b/docs/react/week-3/demos/ExerciseG.js
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+
+import Demo from "@theme/Demo";
+
+export function ExerciseGDemo() {
+  return (
+    <Demo>
+      <CaughtPokemon date={new Date().toLocaleDateString()} />
+    </Demo>
+  );
+}
+
+function CaughtPokemon(props) {
+  const [caught, setCaught] = useState([]);
+  const [pokemonNameInput, setPokemonNameInput] = useState("");
+
+  function catchPokemon() {
+    if (pokemonNameInput === "") {
+      return;
+    }
+
+    setCaught(caught.concat(pokemonNameInput));
+    setPokemonNameInput("");
+  }
+
+  function handleInputChange(event) {
+    console.log(event.target.value);
+    setPokemonNameInput(event.target.value);
+  }
+
+  return (
+    <p>
+      Caught {caught.length} Pokemon on {props.date}
+      <ul>
+        {caught.map((name, index) => {
+          return <li key={index}>{name}</li>;
+        })}
+      </ul>
+      <input
+        type="text"
+        value={pokemonNameInput}
+        onChange={handleInputChange}
+      />
+      <button onClick={catchPokemon}>Catch Pokemon</button>
+    </p>
+  );
+}
+
+function getRandomPokemon() {
+  const pokemon = ["Ditto", "Eevee", "Pikachu", "Butterfree", "Spearow"];
+  return pokemon[Math.floor(Math.random() * pokemon.length)];
+}

--- a/docs/react/week-3/lesson.md
+++ b/docs/react/week-3/lesson.md
@@ -4,6 +4,9 @@ title: React - Week 3
 sidebar_label: Lesson
 ---
 
+<!-- Docusaurus allows embedding React components via MDX -->
+<!-- https://v2.docusaurus.io/docs/markdown-features#embedding-react-components-with-mdx -->
+
 import Feedback from "@theme/Feedback";
 import { ExerciseADemo } from './demos/ExerciseA.js'
 import { ExerciseEDemo } from './demos/ExerciseE.js'

--- a/docs/react/week-3/lesson.md
+++ b/docs/react/week-3/lesson.md
@@ -5,6 +5,10 @@ sidebar_label: Lesson
 ---
 
 import Feedback from "@theme/Feedback";
+import { ExerciseADemo } from './demos/ExerciseA.js'
+import { ExerciseEDemo } from './demos/ExerciseE.js'
+import { ExerciseFDemo } from './demos/ExerciseF.js'
+import { ExerciseGDemo } from './demos/ExerciseG.js'
 
 ---
 
@@ -168,6 +172,7 @@ You might notice that even though we re-rendered, we did **not** run the `useEff
 
 | Exercise A (estimate: 15 min)                                                                                                                                                                                                                              |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll fetch some data about a Pokemon's moves from the Pokemon API and render it a component: <ExerciseADemo />                                                                                                                          |
 | 1. Open the `pokedex` React application again.                                                                                                                                                                                                             |
 | 2. Create a new file `src/PokemonMoves.js`, and copy/paste the code from [this CodeSandbox](https://codesandbox.io/s/pokemonmoves-useeffect-exercise-starting-point-f1mwm?file=/src/PokemonMoves.js).                                                      |
 | 3. Render the `PokemonMoves` component inside the `App` component (underneath `CaughtPokemon`).                                                                                                                                                            |
@@ -219,10 +224,11 @@ return (
 
 You'll notice in the `&&` example above, we do not render a 'Loading...' message, because there is no alternative output (no `else` case).
 
-| Exercise B (estimate: 5 min)                                                                                                        |
-| :---------------------------------------------------------------------------------------------------------------------------------- |
-| 1. Open the `pokedex` application and the `src/PokemonMoves.js` file.                                                               |
-| 2. Change the `if` / `else` statement in your JSX to use the ternary operator (`condition ? outputIfTrue : outputIfFalse`) instead. |
+| Exercise B (estimate: 5 min)                                                                                                                              |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll change the `PokemonMoves` component to use a ternary operator. Your app should still look the same in your browser as Exercise A. |
+| 1. Open the `pokedex` application and the `src/PokemonMoves.js` file.                                                                                     |
+| 2. Change the `if` / `else` statement in your JSX to use the ternary operator (`condition ? outputIfTrue : outputIfFalse`) instead.                       |
 
 ### The Circle of Life
 
@@ -433,6 +439,7 @@ To help you understand this better, try "playing computer" again, but this time 
 
 | Exercise E (estimate: 10 min)                                                                                                                                                                                                                                                                                                                                                          |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we'll add some buttons which allow you to select which Pokemon's moves we will fetch from the Pokemon API: <ExerciseEDemo />                                                                                                                                                                                                                                         |
 | 1. Open the `pokedex` React application.                                                                                                                                                                                                                                                                                                                                               |
 | 2. Create a new file `src/PokemonMovesSelector.js`. Copy/paste the code from [this CodeSandbox](https://codesandbox.io/s/pokemonmovesselector-exercise-starting-point-wt5d0) into the new file.                                                                                                                                                                                        |
 | 3. Open `src/App.js` and replace the `PokemonMoves` component with the `PokemonMovesSelector` component (remember to update the `import` too!)                                                                                                                                                                                                                                         |
@@ -492,6 +499,7 @@ In addition, instead of just saving the value of the input in the state, we coul
 
 | Exercise F (estimate: 10 min)                                                                                                                                                                           |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| In this exercise, we'll create a new component where you can type in the name of a Pokemon city and see it on screen. <ExerciseFDemo />                                                                 |
 | 1. Open the `pokedex` React application.                                                                                                                                                                |
 | 2. Create a new file `src/PokemonCity.js`. Copy/paste the code from [this CodeSandbox](https://codesandbox.io/s/pokemon-city-exercise-starting-point-6wivm?file=/src/PokemonCity.js) into the new file. |
 | 3. Open the `src/App.js` file and render the new `PokemonCity` component (underneath `PokemonMovesSelector`).                                                                                           |
@@ -561,6 +569,7 @@ We now have three different inputs named `username`, `email` and `password`. The
 
 | Exercise G (estimate: 10 min)                                                                                                                                                                              |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| In this exercise, we will change the `CaughtPokemon` component so that you can type in the name of a Pokemon that you caught and it will show in the list: <ExerciseGDemo />                               |
 | 1. Open the `pokedex` React application again and open the `src/CaughtPokemon.js` file.                                                                                                                    |
 | 2. Render an `<input>` before the `<button>` (hint: `<input type="text" />`).                                                                                                                              |
 | 3. Create a new state variable called `pokemonNameInput` and initialise to an empty string (`""`).                                                                                                         |

--- a/docs/react/week-3/mentors.md
+++ b/docs/react/week-3/mentors.md
@@ -13,6 +13,7 @@ sidebar_label: Instructor Notes
 
 - [PokeDex In-Class - Exercise Solution - 05/06/2020](https://github.com/CodeYourFuture/pokedex-solution)
   - Created by London and Ali Smith
+  - These are now embedded into the syllabus itself, see [`demos` folder](https://github.com/CodeYourFuture/syllabus/tree/master/docs/react/week-3/demos) for source
 - [Hotel Homework - Solution - 24/07/2020](https://github.com/CodeYourFuture/Hotel-React-solution)
   - Created by Manchester and Dorota Sobkow
 


### PR DESCRIPTION
## What does this change?

Module: React
Week(s): 1- 3

## Description

<!-- Add a description of what your PR changes here -->
Closes https://github.com/CodeYourFuture/syllabus/issues/72

Pretty much does what it says on the tin. Adds components to demonstrate the final state of (relevant) Pokedex in-class exercises.

Example screenshot:

![Screenshot 2020-10-17 at 15 21 37](https://user-images.githubusercontent.com/424411/96339412-75a2c700-108c-11eb-82c0-f7c3ef85b36f.png)

To view the demos themselves, you'll probably have to pull and run locally as rendering React is not supported by Github's markdown parser.

## Who needs to know about this?

<!---
Tag anyone who might want to be notified about this PR
-->
@ChrisOwen101 
@nbogie 