### PR TITLE
Remove a couple of more advanced coding standards

### DIFF
--- a/docs/guides/coding-standards.md
+++ b/docs/guides/coding-standards.md
@@ -25,7 +25,6 @@ https://github.com/airbnb/javascript
     - hyphen-case or camelCase for CSS
   - Do not mix casing styles e.g. let first_name = person.firstName;
 
-- Test coverage should be sufficient
 - Comment code that might be difficult to understand...
   - ...but also consider simplifying complex code if at all possible. If you
     find that you're writing a lot of comments, then it's a good indicator that
@@ -55,12 +54,6 @@ https://github.com/airbnb/javascript
 - **Don't** use ID-based selectors e.g. `#some-id`
 - Avoid styling HTML element selectors directly, unless it's to remove default
   browser styling
-
-- Avoid using style properties in JavaScript
-  - E.g. `myElement.style.display = 'none';`
-  - This results in styles that are difficult to reuse
-  - Use `Element.prototype.classList` instead e.g.
-    `myElement.classList.add('hidden');`
 
 ## Git
 


### PR DESCRIPTION
We don't teach our learners about testing, so we shouldn't tell them to
have test coverage.

We explicitly teach them about setting style properties, so it's
probably confusing to tell them not to use them while we're teaching
them. It feels like we really want a document which grows
module-by-module, with each stage covering just what we've taught
them...

But if we're going to link to this in every week's repo, we should
probably remove at least these things.