### PR TITLE
Clarify assertions in JS-1 Week 2 lesson

### DIFF
--- a/docs/js-core-1/week-2/lesson.md
+++ b/docs/js-core-1/week-2/lesson.md
@@ -133,7 +133,7 @@ In the previous exercise, you used an **expression** that returns a `boolean` va
 
 ### Assert
 
-We will also be using a new keyword to make sure the comparisons we do below return `true`. This is the `assert`.
+We will also be using a new function to make sure the comparisons we do below return `true`. This is the `assert`.
 
 When given `true`, it does nothing. Nice. When given `false`, it will error. It is very good for testing things you expect to be `true`.
 

--- a/docs/js-core-1/week-2/lesson.md
+++ b/docs/js-core-1/week-2/lesson.md
@@ -135,6 +135,8 @@ In the previous exercise, you used an **expression** that returns a `boolean` va
 
 We will also be using a new function to make sure the comparisons we do below return `true`. This is the `assert`.
 
+It is not a built-in function like `console.log`, it is part of the NodeJS library, and it has to be loaded with the `require("assert")` command.
+
 When given `true`, it does nothing. Nice. When given `false`, it will error. It is very good for testing things you expect to be `true`.
 
 Here's an expression that evaluates to a `boolean`.


### PR DESCRIPTION
## What does this change?

Module: JS-1
Week(s): 2

## Description

Fix two issues:
1. The lesson incorrectly states that `assert` is a keyword, while it is a function in JavaScript.
2. The exercise for comparison operators starts with `const assert = require("assert")` without explaining what it is and why it is used; add a very brief explanation.