### PR TITLE
js-3/week-1: Fix copy-paste error in an exercise description

### DIFF
--- a/docs/js-core-3/week-1/lesson.md
+++ b/docs/js-core-3/week-1/lesson.md
@@ -50,7 +50,7 @@ Therac-25 was a machine used to administer radiation to cancer patients which ma
 
 **Watch**: You can watch a quick video about the bug [here](https://www.youtube.com/watch?v=izGSOsAGIVQ)
 
-**Discuss**: Why did the Y2K bug happen? What oversights did the developers have?
+**Discuss**: Why did the Therac-25 bug happen? What oversights did the developers have?
 
 ### The Debugging Mindset
 


### PR DESCRIPTION
The second exercise about bugs should refer to the Therac-25 bug and not the Y2K bug. (The first exercise is about the Y2K bug.)

## What does this change?

Module: JS-3
Week(s): 1

