### PR TITLE
js-3/week-2: Add freeCodeCamp tutorial about promises to homework

### DIFF
--- a/docs/js-core-3/week-2/homework.md
+++ b/docs/js-core-3/week-2/homework.md
@@ -19,13 +19,14 @@ In each of the folders you'll find a `solutions.md` file that will explain more 
 
 -->
 
-## 1) Practice the concepts (1 hours)
+## 1) Practice the concepts (2 hours)
 
 This week's concepts can be challenging, therefore let's get an easy introduction using some interactive exercises! Check the following resources out and start practicing.
 
 You can ignore anything to do with `XMLHttpRequest`
 
 - FreeCodeCamp
+  - https://www.freecodecamp.org/news/javascript-es6-promises-for-beginners-resolve-reject-and-chaining-explained/
   - https://www.freecodecamp.org/news/a-practical-es6-guide-on-how-to-perform-http-requests-using-the-fetch-api-594c3d91a547/
 
 ## 2) Code along (1 hour)


### PR DESCRIPTION
## What does this change?

Module: JS-3
Week(s): 2

## Description

The homework already includes a freeCodeCamp tutorial about `fetch`, but
in order to understand `fetch`, students should understand promises
first. Promises are also new material covered in this session, and they
are not easy to grasp at first glance.
