### PR TITLE
Added white background for diagrams

### DIFF
--- a/docs/html-css/week-1/lesson.md
+++ b/docs/html-css/week-1/lesson.md
@@ -150,7 +150,7 @@ The `html` element declares that it is an HTML document, and contains a `head` a
 
 HTML tags are arranged in a hierarchy. This is sometimes called **nesting** tags or creating an HTML **tree**. Between the opening `<article>` tag and the closing `</article>` tag there are three other tags. We call these **child** tags, because they have a parent-child relationship.
 
-<img src={require('!file-loader!../assets/html-hierarchy.png').default}
+<img class="onDarkMode_whiteBg" src={require('!file-loader!../assets/html-hierarchy.png').default}
 alt="Tree diagram showing an article tag with h1, p, and a tags as direct children"/>
 
 :::note Exercise (5 minutes)

--- a/docs/js-core-2/week-3/lesson.md
+++ b/docs/js-core-2/week-3/lesson.md
@@ -221,7 +221,7 @@ All set, go! Work on the tasks given. Your result html will look like this:
 
 ### Client/Server architecture
 
-<img src={require('!file-loader!./assets/client-server.png').default} />
+<img class="onDarkMode_whiteBg" src={require('!file-loader!./assets/client-server.png').default} />
 
 A **Client** is the typical web user's internet-connected devices and apps. This can be a web browser, a Slack app, your phone, etc.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -51,3 +51,7 @@
 .mt-1 {
   margin-top: 16px;
 }
+
+.onDarkMode_whiteBg {
+  background: white;
+}


### PR DESCRIPTION
## What does this change?

Module: HTML/CSS & JS Core 2
Week(s): 1 & 2

## Description

<!-- Add a description of what your PR changes here -->

This is a fix for issue #240 where I added a CSS rule to apply to two diagrams that were not as visible in Dark Mode. Here is a before:
<img width="499" alt="Screen Shot 2021-05-12 at 2 14 57 PM" src="https://user-images.githubusercontent.com/64915527/118025589-02b1b400-b32e-11eb-84b6-9ce43116416b.png">

...and after:
<img width="492" alt="Screen Shot 2021-05-12 at 2 14 36 PM" src="https://user-images.githubusercontent.com/64915527/118025612-09d8c200-b32e-11eb-885e-26bfea709d73.png">

<!--
  For ease of review, consider adding a "rendered" version (using GitHub's
  markdown renderer) of the file(s) that you changed by adding a link in this
  format:

  [Rendered version](https://github.com/CodeYourFuture/syllabus/blob/YOUR_BRANCH_NAME/PATH/TO/THE/CHANGED/FILE.md)
-->

## Who needs to know about this?

@ChrisOwen101 

<!---
Tag anyone who might want to be notified about this PR
-->
