### PR TITLE
Add Git Delivery Times to Overview Page

### DIFF
--- a/docs/git/coordinator.md
+++ b/docs/git/coordinator.md
@@ -8,12 +8,9 @@ sidebar_label: Module Coordinator
 
 This module is unusual as it follows an irregular delivery pattern
 
-- Lesson 1 - Delivered on the second week of the full stack course
-- Lesson 2 - Assigned as Coursework after JavaScript Core 1 Week 3
-- Lesson 3 - Assigned as Coursework after JavaScript Core 2 Week 1
-- Lesson 4 - Assigned as Coursework after JavaScript Core 2 Week 3
-
 The content has been written to be delivered in this specific way to make the best use of Trainee's time through the course.
+
+See the [Overview](./overview) page for when the lessons are given.
 
 ## 2) Preparation
 

--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -10,6 +10,21 @@ Git is a version control tool, used to keep the history of changes, and make col
 
 Each week, you're going to use Git to get a copy of your Coursework exercises, to submit your solutions, and to get feedback on your solutions. Today, you're going to learn how to do these things.
 
+## How is this module delivered?
+
+This module is different to others at CodeYourFuture because some it taught in class and some is assigned as coursework.
+
+These lessons will be assigned at the following times:
+
+- Lesson 1 - Delivered on the second week of the Full Stack course
+- Lesson 2 - Assigned as Coursework after JavaScript Core 1 Week 3
+- Lesson 3 - Assigned as Coursework after JavaScript Core 2 Week 1
+- Lesson 4 - Assigned as Coursework after JavaScript Core 2 Week 3
+
+If you want, you can complete the lessons **before** they are given as coursework - but there is no requirement to.
+
+## Lesson Overview
+
 | Lesson                             | Content                 | Coursework                                     | When is this delivered?                               |
 | ---------------------------------- | ----------------------- | ---------------------------------------------- | ----------------------------------------------------- |
 | [Lesson 1](./desktop/lesson)       | Github & Github Desktop | [Git Coursework](./desktop/homework)           | On Week 2 of the Full Stack Course                    |

--- a/docs/git/overview.md
+++ b/docs/git/overview.md
@@ -10,11 +10,9 @@ Git is a version control tool, used to keep the history of changes, and make col
 
 Each week, you're going to use Git to get a copy of your Coursework exercises, to submit your solutions, and to get feedback on your solutions. Today, you're going to learn how to do these things.
 
-
-
-| Lesson                             | Content                 | Coursework                                     | When is this delivered?            |
-| ---------------------------------- | ----------------------- | ---------------------------------------------- | ---------------------------------- |
-| [Lesson 1](./desktop/lesson)       | Github & Github Desktop | [Git Coursework](./desktop/homework)           | On Week 2 of the Full Stack Course |
+| Lesson                             | Content                 | Coursework                                     | When is this delivered?                               |
+| ---------------------------------- | ----------------------- | ---------------------------------------------- | ----------------------------------------------------- |
+| [Lesson 1](./desktop/lesson)       | Github & Github Desktop | [Git Coursework](./desktop/homework)           | On Week 2 of the Full Stack Course                    |
 | [Lesson 2](./terminal/lesson)      | The Terminal            | [Terminal Coursework](./terminal/homework)     | As Coursework (see [Coordinator](./coordinator) page) |
 | [Lesson 3](./cli/lesson)           | Git on the Command Line | [Git CLI Coursework](./cli/homework)           | As Coursework (see [Coordinator](./coordinator) page) |
 | [Lesson 4](./branches/branches.md) | Branches                | [Git Branches Coursework](./branches/homework) | As Coursework (see [Coordinator](./coordinator) page) |


### PR DESCRIPTION
## What does this change?

Module: Git

## Description

There's some confusion from our volunteers about when the Git module is assigned to students. 

I've moved the information from the relatively hidden Coordinator page and moved it to the Overview page so it's harder to miss. 

## Who needs to know about this?

