### PR TITLE
Mention Git/Terminal courseworks on Coursework pages

### DIFF
--- a/docs/js-core-1/week-3/homework.md
+++ b/docs/js-core-1/week-3/homework.md
@@ -85,7 +85,11 @@ Every week you need to complete at least three kata. Spend at least 20 minutes, 
 
 Find the collection for JS-1 Week 3 on the CodeYourFuture account: https://www.codewars.com/users/CodeYourFuture/authored_collections
 
-## 7) (Stretch) Extra JavaScript Challenges
+## 7) Learn About the Terminal (8 hours)
+
+Most developers spend a lot of time using something called the terminal. This week, you are going to follow a course to learn about the terminal - it has [its own homework page here](/git/terminal/homework) for you to work from.
+
+## 8) (Stretch) Extra JavaScript Challenges
 
 Have some extra time before our next class? Fill it with these harder challenges to help you stretch your abilities!
 

--- a/docs/js-core-2/week-3/homework.md
+++ b/docs/js-core-2/week-3/homework.md
@@ -94,13 +94,17 @@ Every week you need to complete at least three kata. Spend at least 20 minutes, 
 
 Find the Collection for JS-2 Week 3 on the CodeYourFuture account: https://www.codewars.com/users/CodeYourFuture/authored_collections
 
-## 6) (Stretch) Add extra features to your Challenges (5 hours)
+## 6) Learn About Git Branches (5 hours)
+
+Continuing your background learning about Git, this week you're going to learn about something called branches. [You'll find the lesson to follow here](/git/branches/homework).
+
+## 7) (Stretch) Add extra features to your Challenges (5 hours)
 
 In the "Extra" folder of this repository you will find extra tasks for you to complete.
 
 https://github.com/CodeYourFuture/JavaScript-Core-2-Coursework-Week3
 
-## 7) (Stretch) Codeacademy Course
+## 8) (Stretch) Codeacademy Course
 
 The end of this module is a really good opportunity to cover everything we've done over the last six weeks.
 


### PR DESCRIPTION
We already had this for JS2W1 but apparently missed the others.

Fixes #310