### PR TITLE
Update HTML/CSS coursework

### DIFF
--- a/docs/html-css/week-1/homework.md
+++ b/docs/html-css/week-1/homework.md
@@ -4,28 +4,14 @@ title: Coursework
 sidebar_label: Coursework
 ---
 
-### 1) CSS Diner (3 hours)
+## Mandatory coursework
 
-This online game will help you learn Advanced CSS Selectors.
+### 1) 🔑 Create your own webpage (4 hours)
 
-You should complete every level before moving onto the next part of the homework.
+Fork then clone the [HTML/CSS week 1 coursework](https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week1), and follow the instructions in the `README.md` file.
 
-https://flukeout.github.io/
+## Optional coursework
 
-## 2) HTML/CSS Project (5 hours)
+### 2) CSS Diner game (optional, 3 hours)
 
-In this repository you will find a project for you to complete
-
-https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week1
-
-Before you start, **make sure you fork the repository** to your Github account.
-
-## 3) Prepare for the next class (2 hours)
-
-Complete the first three lessons in this course on [Responsive Web Design Fundamentals](https://www.udacity.com/course/responsive-web-design-fundamentals--ud893).
-
-https://www.udacity.com/course/responsive-web-design-fundamentals--ud893
-
-You should complete **Why Responsive?**.
-
-_Don't worry if you don't have a phone you can use for Remote Debugging. You can use the browser's Device Emulation instead._
+Try to complete all levels of the [CSS Diner game](https://flukeout.github.io) to get practise on advanced CSS selectors.

--- a/docs/html-css/week-2/homework.md
+++ b/docs/html-css/week-2/homework.md
@@ -4,32 +4,22 @@ title: Coursework
 sidebar_label: Coursework
 ---
 
-## 1) Complete Flexbox Froggy (3 hours)
+## Mandatory coursework 
 
-Flexbox Froggy is a really fun way of learning how Flexbox works.
+### 1) 🔑 Create a Karma clone webpage (4 hours)
 
-You should complete all the levels
+Fork then clone the [HTML/CSS week 2 coursework](https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week2), and follow the instructions in the `README.md` file.
 
-https://flexboxfroggy.com/
+### 2) Complete Flexbox Froggy game (3 hours)
 
-## 2) Flexbox Project (4 hours)
+Complete all levels of the [Flexbox Froggy game](https://flexboxfroggy.com) to get practise on flexbox.
 
-In this repository you will find a project for you to complete
+## Optional coursework
 
-https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week2
+### 3) Complete the Zoo CSS challenge (optional)
 
-Before you start, **make sure you fork the repository** to your Github account.
+Now that we have learned flexbox, complete the [Zoo CSS challenge](https://github.com/CodeYourFuture/HTML-CSS-Challenges).
 
-## 3) Complete the CSS Zoo project
+### 4) Complete the Bikes For Refugees project (optional)
 
-Now that we have learned Flexbox, complete the [Zoo project](https://github.com/CodeYourFuture/HTML-CSS-Challenges).
-
-## 4) Complete the Bikes For Refugees project
-
-Now that we have learned Flexbox, complete the [Bikes For Refugees project](https://github.com/CodeYourFuture/bikes-for-refugees).
-
-## 5) Prepare for the next class (1 Hour)
-
-Look at the documentation for "Bootstrap 4" and look at their examples to see how they are building components.
-
-https://getbootstrap.com/docs/4.4/getting-started/introduction/
+Now that we have learned flexbox, complete the [Bikes For Refugees project](https://github.com/CodeYourFuture/bikes-for-refugees).

--- a/docs/html-css/week-3/homework.md
+++ b/docs/html-css/week-3/homework.md
@@ -4,33 +4,8 @@ title: Coursework
 sidebar_label: Coursework
 ---
 
-## 1) Why Responsive? (5 hours)
+## Mandatory coursework
 
-You should complete the whole course of Lesson 1 - "Why Responsive?"
+### 1) 🔑 Create a Cakes Co webpage (4 hours)
 
-Don't worry if you don't have a phone you can use for Remote Debugging. You can use the browser's Device Emulation instead.
-
-https://www.udacity.com/course/responsive-web-design-fundamentals--ud893
-
-## 2) Responsive Cake Website Project (4 hours)
-
-In this repository you will find a project for you to complete
-
-https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week3
-
-Before you start, **make sure you fork the repository** to your Github account.
-
-## 3) Prepare for the next class (2 hours)
-
-Next lesson, we will be going back to learning about JavaScript.
-
-Review what you've learnt so far to prepare yourself for the next lesson.
-
-We recommend that you
-
-- Complete some online courses to see what gaps you have in your knowledge you have
-- Prepare any questions you have about basic JavaScript
-- Have a call with other trainees to discuss anything you don't understand.
-
-You should always read through the next lesson, in preparation for class. For JS-1 you need to complete this prep:
-https://syllabus.codeyourfuture.io/js-core-1/preparation
+Fork then clone the [HTML/CSS week 3 coursework](https://github.com/CodeYourFuture/HTML-CSS-Coursework-Week3), and follow the instructions in the `README.md` file.


### PR DESCRIPTION
## What does this change?

Module: HTML/CSS
Week(s): 1-3

## Description

- Organise coursework into mandatory and optional sections
- Mark the most important piece of coursework with a 🔑
- Remove the Udacity coursework as they are not hugely useful
- Remove the Bootstrap preparation as it is unguided

Related issue: https://github.com/CodeYourFuture/syllabus/issues/308

## Who needs to know about this?

## Rendered Pages


-----
[View rendered docs/html-css/week-1/homework.md](https://github.com/CodeYourFuture/syllabus/blob/update-html-css-coursework/docs/html-css/week-1/homework.md)
[View rendered docs/html-css/week-2/homework.md](https://github.com/CodeYourFuture/syllabus/blob/update-html-css-coursework/docs/html-css/week-2/homework.md)
[View rendered docs/html-css/week-3/homework.md](https://github.com/CodeYourFuture/syllabus/blob/update-html-css-coursework/docs/html-css/week-3/homework.md)