### PR TITLE
JS-3 Week 2: Update the API URLs in the group exercise

### DIFF
--- a/docs/js-core-3/week-2/lesson.md
+++ b/docs/js-core-3/week-2/lesson.md
@@ -330,7 +330,7 @@ fetch("https://httpstat.us/500")
 
 In groups the trainees should create a page of details about the United Kingdom.
 
-The API endpoint can be found [here](https://restcountries.eu/rest/v2/name/Great%20Britain?fullText=true)
+The API endpoint can be found [here](https://restcountries.com/v3.1/name/Great%20Britain)
 
 The website should include
 
@@ -340,7 +340,7 @@ The website should include
 
 #### Getting Started
 
-1. Go to [this Glitch Project](https://glitch.com/edit/#!/js3-2-country-exercise?path=README.md%3A3%3A80)
+1. Go to [this Glitch Project](https://glitch.com/edit/#!/js3-2-country-exercise-v2?path=README.md)
 2. Click `Remix to Start` to being working
 
 #### Steps


### PR DESCRIPTION
## What does this change?

Module: JS core 3
Week(s): 2

## Description

The group exercise for `fetch` relies on the [REST Countries API](https://restcountries.com/).

It has been moved from restcountries.eu to the restcountries.com domain and the API has been updated from v2 to v3.1.

Update the API URL and add link to an updated Glitch project.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/js-core-3/week-2/lesson.md](https://github.com/szemate/syllabus/blob/js-core-3/week-2/update-group-exercise/docs/js-core-3/week-2/lesson.md)