### PR TITLE
JS-3 Week 2: Replace the TfL API exercise with an easier one

### DIFF
--- a/docs/js-core-3/week-2/lesson.md
+++ b/docs/js-core-3/week-2/lesson.md
@@ -173,15 +173,12 @@ As you can see the URL changes the data that we get from the API. This can be br
 
 :::note Exercise
 
-Let's use the TFL API to get data about the London Underground
+The purpose of the exercise is to get used to interpreting API documentation.
 
-https://api.tfl.gov.uk
+Let's use the Chuck Norris Jokes API. The documentation can be found at https://api.chucknorris.io/.
 
-1. Which endpoint would you use to find out if there is a disruption on the 'central' line?
-2. Does the 'central' line have a disruption right now?
-3. Name another line that has a disruption on it.
-
-Hint: Use your browser to access the endpoints
+1. Read the "Usage" section and try each endpoint in the browser.
+2. Retrieve a random Chuck Norris joke related to _movies_. You will need to get data from one endpoint and then use it to retrieve data from another endpoint.
 
 :::
 


### PR DESCRIPTION
## What does this change?

Module: JS Core 3
Week(s): 2

## Description

I've been a lead teacher for JS-3 week 2 three times, and it's been a recurring comment from trainees and TAs that the TfL API exercise is confusing because the API is complex and the documentation is a bit obscure for someone who sees a REST API for the first time.

Replace it with an easier exercise that uses the [Chuck Norris Jokes API](https://api.chucknorris.io/).

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/js-core-3/week-2/lesson.md](https://github.com/szemate/syllabus/blob/js-core-3/week-2/replace-api-exercise/docs/js-core-3/week-2/lesson.md)