### PR TITLE
Update navigation to pass tests

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,204 +49,156 @@ module.exports = {
         {
           to: "Overview",
           label: "Overview",
-          position: "left",
+          
         },
         {
+          to: "Overview",
           label: "Modules",
-          position: "left",
+          
           items: [
             {
               href: "https://introtocoding.codeyourfuture.io",
               label: "Intro To Coding",
-              position: "left",
-              className: "outside-link",
+              
             },
             {
               href: "https://fundamentals.codeyourfuture.io/",
               label: "Fundamentals",
-              position: "left",
-              className: "outside-link",
             },
             {
               href: "https://personaldevelopment.codeyourfuture.io/em-modules/induction-week",
               label: "Induction",
-              position: "left",
-              className: "outside-link",
             },
             {
               to: "git/overview",
               label: "Git and Github",
-              position: "left",
             },
             {
-              to: "html-css/index",
+              to: "html-css/",
               label: "HTML-CSS",
-              position: "left",
             },
             {
-              to: "js-core-1/index",
+              to: "js-core-1/",
               label: "JavaScript Core 1",
-              position: "left",
             },
             {
-              to: "js-core-2/index",
+              to: "js-core-2/",
               label: "JavaScript Core 2",
-              position: "left",
             },
             {
-              to: "js-core-3/index",
+              to: "js-core-3/",
               label: "JavaScript Core 3",
-              position: "left",
             },
             {
-              to: "react/index",
+              to: "react/",
               label: "React",
-              position: "left",
             },
             {
-              to: "node/index",
+              to: "node/",
               label: "Node",
-              position: "left",
             },
             {
-              to: "db/index",
+              to: "db/",
               label: "SQL",
-              position: "left",
-            },
-            {
-              to: "mongodb/index",
-              label: "MongoDB",
-              position: "left",
             },
             {
               to: "finalproject/intro",
               label: "Final Projects",
-              position: "left",
             },
           ],
         },
         {
           label: "Workshops",
-          position: "left",
           items: [
             {
-              to: "workshops/accessibility/index",
+              to: "workshops/accessibility/",
               label: "Accessibility Workshops",
-              position: "left",
             },
             {
               to: "workshops/aws-dynamodb",
               label: "AWS & DynamoDB Workshop",
-              position: "left",
             },
             {
               to: "workshops/processing-js-workshop",
               label: "Processing.js Workshop",
-              position: "left",
             },
             {
               to: "workshops/js-testing-workshop",
               label: "JavaScript Testing Workshop",
-              position: "left",
             },
             {
-              to: "workshops/deployment/index",
+              to: "workshops/deployment/",
               label: "Deploying Your Code Workshop",
-              position: "left",
             },
             {
-              to: "workshops/interviews/index",
+              to: "workshops/interviews/",
               label: "Interviews",
-              position: "left"
-            },
-            {
-              label: "-----------",
-              position: "left",
             },
             {
               href: "https://github.com/CodeYourFuture/syllabus/issues/new?assignees=&labels=Workshop&template=workshop-request.md&title=%5BWorkshop%5D",
               label: "Want to request a workshop?",
-              position: "left",
             },
           ],
         },
         {
           label: "Guides",
-          position: "left",
           items: [
             {
               to: "guides/paradigm",
               label: "Our Approach",
-              position: "left",
             },
             {
               to: "guides/marking-guide",
               label: "Marking Guide",
-              position: "left",
             },
             {
               to: "guides/code-style-guide",
               label: "Code Style Guide",
-              position: "left",
             },
             {
               to: "guides/coding-101",
               label: "Coding 101",
-              position: "left",
             },
             {
               to: "guides/escalation-policy",
               label: "Escalation Policy",
-              position: "left",
             },
             {
               to: "guides/react-cheatsheet",
               label: "React Cheatsheet",
-              position: "left",
             },
             {
               to: "guides/useful-links",
               label: "Useful Links",
-              position: "left",
             },
             {
               to: "guides/creating-a-react-app",
               label: "Creating a React App",
-              position: "left",
             },
             {
               to: "guides/intro-to-tests",
               label: "Introduction to tests",
-              position: "left",
             },
           ],
         },
         {
           label: "Other",
-          position: "left",
           items: [
             {
               href: "https://teachertraining.codeyourfuture.io",
               label: "Teacher Training",
-              position: "left",
-              className: "outside-link",
             },
             {
               href: "https://docs.codeyourfuture.io",
               label: "Organisation Documentation",
-              position: "left",
-              className: "outside-link",
             },
             {
               href: "https://personaldevelopment.codeyourfuture.io",
               label: "Personal Development",
-              position: "left",
-              className: "outside-link",
             },
           ],
         },
         {
-          position: "right",
           to: "contributing/overview",
           label: "Want to contribute?",
         },


### PR DESCRIPTION
The latest Docusaurus won't run with improper config so I've updated the navigation to pass the tests.

I've also removed Mongo from the main nav, but not the module from syllabus. 

## What does this change?

Module: MongoDB
Week(s): n/a

## Description

<!-- Add a description of what your PR changes here -->
Removed all the 'left' stuff so the navigation would build without these errors:

```
A validation error occurred.
The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
We may have made some mistakes.
If you think your configuration is valid and should keep working, please open a bug report.
```

ValidationError: "navbar.items[1].items[0].position" is not allowed

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
