### PR TITLE
Up heading level of Professional Development section

### DIFF
--- a/docs/html-css/week-2/lesson.md
+++ b/docs/html-css/week-2/lesson.md
@@ -513,24 +513,23 @@ In software, we follow the rule that we **never** trust user input.
 Learning about web security is outside the scope of this module,
 but if you want an introduction to web security, visit the [MDN website security page](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Website_security).
 
-### Professional Development (60 minutes)
+## Professional Development (60 minutes)
 
 Exercise (Deliver a tutorial based on what you have learned so far to three different audiences ) (20 minutes)
 It's time to train the trainer and practice your communication skills, your task is to pick an audience and deliver a short tutorial on:
 
-1) What are HTML forms used for?
-2) How do form control labels benefit users?
-3) Why are forms useful for different types of users? 
-4) 
+1. What are HTML forms used for?
+2. How do form control labels benefit users?
+3. Why are forms useful for different types of users? 
+
 In small groups you must pick an audience:
 
-1) A group of 10 year olds
-2) People who are new internet users 
-3) Your boss
-4) A team of new developers 
+1. A group of 10 year olds
+2. People who are new internet users 
+3. Your boss
+4. A team of new developers 
 
 You have a maximum of three minutes to present back to the wider group. (40 minutes)
-
 
 All trainees are to reflect on what they found challenging and share one positive feedback to the group (10 minutes)
 


### PR DESCRIPTION

## What does this change?

Module: HTML/CSS
Week(s): 2

## Description

* The Professional Development section heading was a level 3 heading placing it in the Forms section. It's now a level 2 to bring it up and out of the forms section.
* Made some numbered list changes to make the document more readable.

## Who needs to know about this?

[ElizabethlawalCYF](https://github.com/ElizabethlawalCYF)

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/html-css/week-2/lesson.md](https://github.com/CodeYourFuture/syllabus/blob/IanTaite-patch-1/docs/html-css/week-2/lesson.md)