### PR TITLE
Remove "Structuring Data" from Lesson 2 summary

### DIFF
--- a/docs/html-css/index.md
+++ b/docs/html-css/index.md
@@ -7,7 +7,7 @@ sidebar_label: Overview
 | Weeks                          | Content                           | Learning Objectives                                    |
 | ------------------------------ | --------------------------------- | ------------------------------------------------------ |
 | [Lesson 1](./week-1/lesson.md) | Fundamentals • Semantics          | [Learning objectives](./week-1/learning-objectives.md) |
-| [Lesson 2](./week-2/lesson.md) | Forms • Structuring Data          | [Learning objectives](./week-2/learning-objectives.md) |
+| [Lesson 2](./week-2/lesson.md) | Forms                             | [Learning objectives](./week-2/learning-objectives.md) |
 | [Lesson 3](./week-3/lesson.md) | Layout • Flexbox • Grid           | [Learning objectives](./week-3/learning-objectives.md) |
 | [Lesson 4](./week-4/lesson.md) | Ship it • Putting it all together | [Learning objectives](./week-4/learning-objectives.md) |
 


### PR DESCRIPTION
There's nothing in lesson 2 related to "structuring data" as far as I can tell, so I've removed the "Structuring Data" label from Lesson 2.

## What does this change?

Module: HTML/CSS
Week(s): 2

## Description

Lesson 2's description is "Forms and Structuring Data", but there's nothing in the lesson content about structuring data.

## Who needs to know about this?

@stevoland @jamesgorrie @frosas @skinofstars 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/html-css/index.md](https://github.com/CodeYourFuture/syllabus/blob/IanTaite-patch-2/docs/html-css/index.md)