### PR TITLE
React minutes for 2022-08-01

### DIFF
--- a/docs/contributing/react/minutes.md
+++ b/docs/contributing/react/minutes.md
@@ -4,4 +4,30 @@ title: React Module Syllabus Team Minutes
 sidebar_label: Team Minutes
 ---
 
-Minutes go here!
+## 2022-08-01
+
+Present: Ali, Alex, Tom, Sharlu, Zach
+
+### The board
+
+- https://github.com/CodeYourFuture/syllabus/projects/10?fullscreen=true
+- Use this to plan and track our work (kanban-style)
+- Feel free to open tickets if there is work that you would like to do
+- Monthly planning: move tickets to the Todo column if someone is going to pick up the ticket in the next month
+
+### Expanding the Hotel coursework
+
+- Problem
+  - The Hotel homework only takes a hour or 2 a week to complete, it could be expanded to have some more exercises
+  - Exercises cover most or all of the content covered in the lesson - but need more practice of those concepts
+  - Strong trainees could do with some more stretch goals - those that challenge them to extend knowledge of the concepts
+- We have a very good set of alternative "challenge" projects that are part of the coursework
+  - However, these are (intentionally) not very "prescriptive", unlike the Hotel coursework
+  - But would still like to keep because trainees gain experience of setting up different React projects, and different problems to solve
+
+### Actions
+
+- Everyone: get familiar with the React module in it's current state
+- Tom: write up ticket for splitting content over 4 weeks
+- Ali: write up ticket for expanding coursework
+- Alex: write up ticket for improving teaching of the concept of state


### PR DESCRIPTION
## What does this change?

Module: N/A
Week(s): N?A

## Description

<!-- Add a description of what your PR changes here -->

Minutes for React module syllabus team meeting on 2022-08-01.

(⚠️ Note: this is chained on to: https://github.com/CodeYourFuture/syllabus/pull/466, which should be merged first)

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

@CodeYourFuture/react 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/contributing/minutes.md](https://github.com/CodeYourFuture/syllabus/blob/react-minutues-2022-08-01/docs/contributing/minutes.md)
[View rendered docs/contributing/react/minutes.md](https://github.com/CodeYourFuture/syllabus/blob/react-minutues-2022-08-01/docs/contributing/react/minutes.md)