### PR TITLE
Fix starter kit link

### DIFF
--- a/docs/finalproject/prep.md
+++ b/docs/finalproject/prep.md
@@ -28,12 +28,9 @@ All trainees should make sure that they are comfortable with their roles and wha
 
 ## Starter Projects
 
-Here is a starter project that trainees can fork to get started:
+Here is a [starter project for Postgres/Express/React/Node](https://github.com/CodeYourFuture/cyf-final-project-starter-kit/).
 
-- Starter project for [Mongo/Express/React/Node](https://github.com/CodeYourFuture/cyf-final-project-starter-kit)
-- Starter project for [Postgres/Express/React/Node](https://github.com/CodeYourFuture/cyf-final-project-starter-kit/tree/postgres) (this is a branch of the above project)
-
-Documentation can be found [here](https://github.com/textbook/starter-kit/wiki) for both of the above projects
+Documentation can be found [here](https://github.com/textbook/starter-kit/wiki).
 
 If you need help for any of these projects, you can find help in this Slack channel: [`#cyf-full-stack-starter-kit`](https://codeyourfuture.slack.com/archives/C021ATWS9A5)
 


### PR DESCRIPTION
There is no longer mongo vs postgres branches -> only link to the main project

## What does this change?

Module:
Week(s):

## Description

<!-- Add a description of what your PR changes here -->

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/finalproject/prep.md](https://github.com/CodeYourFuture/syllabus/blob/gregdyke-fix-starter-kit-link/docs/finalproject/prep.md)