### PR TITLE
Add checklist of pre-tasks for Final Project

### DIFF
--- a/docs/finalproject/prep.md
+++ b/docs/finalproject/prep.md
@@ -4,9 +4,35 @@ title: Final Project Preparation
 sidebar_label: Preparation
 ---
 
+## Checklist to organise Final Projects
+Getting the Final Projects ready is not a task that can be done a week before the module. A lot of decisions have to be made beforehand, so this high-level list of the steps Volunteers and PROM (Programme Managers) should do in order to get everything ready for Final Projects. It also has the main links of important documents. 
+
+**When you are on the React Module**
+- [ ] Must review the trainee’s performance and make [readiness for Final Projects decision](https://docs.google.com/document/d/1jMxqI0L7IKFENCQ8Lw-D1lhnj3c3RZI_WK808wG4YJM/edit?usp=sharing)
+- [ ] Identify trainees that will be filling in roles such as UI/UX Designer, Tester or Product Delivery
+- [ ] Ask internally and externally for possible ideas of charities that could be part of Final Projects. The form used should be [this](https://forms.gle/Gn85Kdna6QB2Qfcp9). 
+- [ ] Start recruiting Tech Lead, Product Managers and UI/UX Designer for Final Projects. See the role descriptions [here](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles). 
+
+**When you are on the NodeJS Module**
+- [ ] Review the project ideas with Tech Leads and Product Managers defining technical feasibility and scope size. You might have to have volunteers clarify some information with the charities
+- [ ] Identify which of the Ideas will be used as a final project. 
+	Send feedback to all charities if they have been chosen or not. 
+	For the chosen ones, clarify the [role](https://docs.codeyourfuture.io/volunteers/teams-1/cyf-products-final-projects/roles/product-owner) and who will be the Product Owner from their Charity. 
+- [ ] Onboard the volunteers with the standard process
+- [ ] Use [this template](https://docs.google.com/spreadsheets/d/16vSSJgzCZJKF-2pwuBTkKjJJJ9i1CGRqMbYB-HEO5mo/edit?usp=sharing) to identify the projects that will be used and who will be on which team
+- [ ] Let volunteers choose which project they would like to be on
+
+**When you are on SQL Module**
+- [ ] Trainees must have finalised the Full Stack assessment 
+- [ ] Must review the trainee’s performance and identify the ones going to Final Projects
+- [ ] Identify trainees that are close in performance and allocate them to the same project. We encourage trainees to work with different people, so try to mix the teams up. Don’t forget to update the spreadsheet.
+- [ ] Have a meeting with all volunteers to go through the details of the final project (presentation to be created with expectation, escalation process, type of support, overview of the trainees per team, etc)
+- [ ] Introduce all teams and people in it and create all Slack groups
+- [ ] A day before the first Saturday of Final Projects, send the project briefing to the team
+
 ## Project Submissions
 
-Some trainees may have some ideas about projects that they would like to complete for their Final Project. Before the Final Project starts, ideas should be gathered and fully specified before the start of the first week.
+As mentioned above, before the Final Project starts ideas should be gathered and fully specified before the start of the first week. The form used to receive these ideas is [this](https://forms.gle/Gn85Kdna6QB2Qfcp9). 
 
 A good project should
 


### PR DESCRIPTION
We have identified that a checklist of the Final Project tasks that must be done way before this module would be handy for PROMs and Volunteers. So I have added this here. PS: I will review the rest of the page too, so will have a second PR soon.

Signed-off-by: KFK <80272258+kfklein15@users.noreply.github.com>

## What does this change?

Module: Final Projects
Week(s): Preparation

## Description

<!-- Add a description of what your PR changes here --> This PR includes a checklist of all tasks that should be done for Final Project starting months before the actual module, to ensure we are all following a similar process

## Who needs to know about this? 

<!-- Tag anyone who might want to be notified about this PR --> @ElizabethlawalCYF @MarianaVazquezCYF @martaesn @AliciaE08 @ShaunCYFSA @caromelendezl 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->


-----
[View rendered docs/finalproject/prep.md](https://github.com/CodeYourFuture/syllabus/blob/kfklein15-patch-1/docs/finalproject/prep.md)