### PR TITLE
a typo fix in the git/desktop/homework file

### DIFF
--- a/docs/git/desktop/homework.md
+++ b/docs/git/desktop/homework.md
@@ -22,7 +22,7 @@ Find your website that you made on CodePen and follow the instructions here
 
 https://blog.codepen.io/documentation/exporting-pens/
 
-When you've completed this step you should a `zip` file downloaded somewhere on your computer.
+When you've completed this step you should have a `zip` file downloaded somewhere on your computer.
 
 ### 2. Unzip File
 


### PR DESCRIPTION
I noticed the word 'have' might be missing, so I thought I'd put what I have learnt into practical practice, find this file on github, and suggest the fix.

Signed-off-by: Hussein Al-Sayed <111397062+hussein-alsayed@users.noreply.github.com>

## What does this change?

Module: Git and Github
Week(s): 1

## Description

<!-- Add a description of what your PR changes here -->
I added what I think might be a missing word in line 25 "When you've completed this step you should -have- a.."
'have' was missing.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
@shieldo @SallyMcGrath @ClaireBickley 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
