### PR TITLE
Fix bug with Fundamentals link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,7 @@ module.exports = {
               label: "Intro To Coding",
             },
             {
-              href: "fundamentals",
+              to: "fundamentals",
               label: "Fundamentals",
             },
             {


### PR DESCRIPTION
As a hangover from being a separate site it was an `href` when it should have been a `to`.

Signed-off-by: Jonathan Sharpe <jonathan@codeyourfuture.io>

## What does this change?

Global navigation

## Description

Updates the link to always take you to the root Fundamentals page

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->
- @SallyMcGrath 
- @kfklein15 

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
