### PR TITLE
Fix typo - description doesn't match variable name

### DIFF
--- a/docs/guides/intro-to-tests.md
+++ b/docs/guides/intro-to-tests.md
@@ -40,8 +40,8 @@ const result = countWords(input);
 ```
 
 In example 1, `input` stores a string `"hello"` which we pass as an argument to `countWords`.
-We then store the return value of `countWords` in a variable called `output`.
-In this case, we would expect the `output` to be 1.
+We then store the return value of `countWords` in a variable called `result`.
+In this case, we would expect the `result` to be 1.
 
 ### Case 2 💼
 
@@ -51,14 +51,14 @@ const result = countWords(input);
 ```
 
 In example 2, `input` stores a string `"I think therefore I am"`, which we pass as an argument to `countWords`.
-We then store the return value of `countWords` in a variable called `output`.
-In this case, we would expect the `output` to be 5.
+We then store the return value of `countWords` in a variable called `result`.
+In this case, we would expect the `result` to be 5.
 
 ### Exercise 🖊️
 
-Write another example with a different `input` variable. What do you expect the `output` to be in this case ?
+Write another example with a different `input` variable. What do you expect the `result` to be in this case ?
 
-We could keep trying out different versions of `input` and check the `output` but real software will often have thousands (or even millions!) of these cases. We can't keep checking all of these ourselves.
+We could keep trying out different versions of `input` and check the `result` but real software will often have thousands (or even millions!) of these cases. We can't keep checking all of these ourselves.
 
 This is where automated testing comes in: we could write some more code that checks whether the cases are working as we expect. Let's look at what an automated test looks like.
 


### PR DESCRIPTION
## What does this change?

Module: Intro to Tests (?)
Week(s): JS1

## Checklist

- [x] I have read the [contributing guidelines](https://syllabus.codeyourfuture.io/contributing/overview)
- [ ] I have checked my spelling and grammar with an [automated tool](https://www.grammarly.com/grammar-check)
- [ ] I have previewed my changes to check the [markdown renders](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as I intend
- [ ] I have run my code to check it works
- [x] My changes follow our [Style Guide](https://syllabus.codeyourfuture.io/guides/code-style-guide)

## Description

Fixing a typo: The description of the code mentions a variable called `output`, but in the code it is called `result`.

## Who needs to know about this?

<!-- Tag anyone who might want to be notified about this PR -->

## Rendered Pages

<!-- Leave this area and below blank. A github bot will render your changed github files for you here. -->
